### PR TITLE
fix: display window icon in taskbar on Windows

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -88,8 +88,7 @@ function createWindow() {
     y: mainWindowState.y,
     show: false,
     autoHideMenuBar: true,
-    icon: join(__dirname, '../../resources/icon.png'),
-    ...(process.platform === 'linux' ? { icon: join(__dirname, '../../resources/icon.png') } : {}),
+    icon: join(__dirname, '../../resources/icon.png'),   
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false


### PR DESCRIPTION
## Problem
Window icon does not appear in the taskbar on Windows.

## Solution
Removed the redundant Linux-only conditional that was preventing the icon from being set on Windows and macOS.

## Changes
- Removed line with `...(process.platform === 'linux' ? ... ` conditional
- Kept the single `icon` property that works for all platforms